### PR TITLE
Trigger resolution failure with bad mock PII

### DIFF
--- a/lib/proofer/vendor/mock.rb
+++ b/lib/proofer/vendor/mock.rb
@@ -34,7 +34,13 @@ module Proofer
       end
 
       def perform_resolution
-        successful_resolution({ kbv: 'some questions here' }, SecureRandom.uuid)
+        if applicant.first_name =~ /Bad/i
+          failed_resolution({ error: 'bad first name' }, SecureRandom.uuid)
+        elsif applicant.ssn == '6666'
+          failed_resolution({ error: 'bad SSN' }, SecureRandom.uuid)
+        else
+          successful_resolution({ kbv: 'some questions here' }, SecureRandom.uuid)
+        end
       end
 
       def build_question_set(_vendor_resp)

--- a/spec/lib/proofer/vendor/mock_spec.rb
+++ b/spec/lib/proofer/vendor/mock_spec.rb
@@ -33,6 +33,22 @@ describe Proofer::Vendor::Mock do
       expect(resolution.session_id).to_not be_nil
       expect(resolution.questions).to be_a Proofer::QuestionSet
     end
+
+    it 'fails on Bad first name' do
+      mocker = described_class.new
+      resolution = mocker.start({ first_name: 'Bad' })
+      expect(resolution).to be_a Proofer::Resolution
+      expect(resolution.success).to eq false
+      expect(resolution.questions).to be_nil
+    end
+
+    it 'fails on 6666 SSN' do
+      mocker = described_class.new
+      resolution = mocker.start({ ssn: '6666' })
+      expect(resolution).to be_a Proofer::Resolution
+      expect(resolution.success).to eq false
+      expect(resolution.questions).to be_nil
+    end
   end
 
   describe '#submit_answers' do


### PR DESCRIPTION
In order to flex the failure paths, add support for trigger values to the mock vendor that return failed Resolution.
