### PR TITLE
Add submit_financials and submit_phone methods

### DIFF
--- a/lib/proofer/agent.rb
+++ b/lib/proofer/agent.rb
@@ -2,7 +2,7 @@ module Proofer
   class Agent
     attr_accessor :vendor
     extend Forwardable
-    def_delegators :@_vendor, :applicant, :applicant=, :start, :submit_answers
+    def_delegators :@_vendor, :applicant, :applicant=, :start, :submit_answers, :submit_financials, :submit_phone
 
     def initialize(opts)
       self.vendor = opts[:vendor] or raise ArgumentError, ":vendor required"

--- a/lib/proofer/vendor/mock.rb
+++ b/lib/proofer/vendor/mock.rb
@@ -23,9 +23,25 @@ module Proofer
           end
         end
         unless report.values.include?(false)
-          successful_confirmation({ report: report })
+          successful_confirmation(report: report)
         else
-          failed_confirmation({ report: report })
+          failed_confirmation(report: report)
+        end
+      end
+
+      def submit_financials(financials, session_id = nil)
+        if financials.is_a?(Hash) && financials[:ccn] == '12345678'
+          successful_confirmation(ok: true)
+        else
+          failed_confirmation(ok: false)
+        end
+      end
+
+      def submit_phone(phone_number, session_id = nil)
+        if phone_number == '(555) 555-5555'
+          successful_confirmation(ok: true)
+        else
+          failed_confirmation(ok: false)
         end
       end
 

--- a/lib/proofer/vendor/vendor_base.rb
+++ b/lib/proofer/vendor/vendor_base.rb
@@ -24,6 +24,14 @@ module Proofer
         raise NoMethodError, "#{self} must implement submit_answers() method"
       end
 
+      def submit_financials(financials, session_id)
+        raise NoMethodError, "#{self} must implement submit_financials() method"
+      end
+
+      def submit_phone(phone_number, session_id)
+        raise NoMethodError, "#{self} must implement submit_phone() method"
+      end
+
       def coerce_applicant(applicant)
         return if applicant.nil?
         return applicant if applicant.is_a?(Proofer::Applicant)

--- a/spec/lib/proofer/agent_spec.rb
+++ b/spec/lib/proofer/agent_spec.rb
@@ -37,9 +37,15 @@ describe Proofer::Agent do
       Proofer::Vendor::Mock::ANSWERS.each do |ques, answ|
         question_set.find_by_key(ques).answer = answ
       end
-      confirmation = agent.submit_answers question_set
-      expect(confirmation.success).to eq true
-      expect(confirmation.success?).to eq true
+      qa_confirmation = agent.submit_answers question_set
+      expect(qa_confirmation.success).to eq true
+      expect(qa_confirmation.success?).to eq true
+
+      financials_confirmation = agent.submit_financials ccn: '12345678'
+      expect(financials_confirmation.success).to eq true
+
+      phone_confirmation = agent.submit_phone '(555) 555-5555'
+      expect(phone_confirmation.success).to eq true
     end
   end
 

--- a/spec/lib/proofer/vendor/mock_spec.rb
+++ b/spec/lib/proofer/vendor/mock_spec.rb
@@ -96,4 +96,40 @@ describe Proofer::Vendor::Mock do
       expect(confirmation.success).to eq false
     end
   end
+
+  describe '#submit_financials' do
+    it 'succeeds with credit card' do
+       mocker = described_class.new applicant: applicant
+       resolution = mocker.start
+       confirmation = mocker.submit_financials({ccn: '12345678'}, resolution.session_id)
+
+       expect(confirmation.success).to eq true
+    end
+
+    it 'fails with bad credit card' do
+      mocker = described_class.new applicant: applicant
+      resolution = mocker.start
+      confirmation = mocker.submit_financials({ccn: '00000000'}, resolution.session_id)
+
+      expect(confirmation.success).to eq false
+    end
+  end
+
+  describe '#submit_phone' do
+    it 'succeeds with all fives' do
+      mocker = described_class.new applicant: applicant
+      resolution = mocker.start
+      confirmation = mocker.submit_phone('(555) 555-5555', resolution.session_id)
+
+      expect(confirmation.success).to eq true
+    end
+
+    it 'fails without all fives' do
+      mocker = described_class.new applicant: applicant
+      resolution = mocker.start
+      confirmation = mocker.submit_phone('(555) 555-1234', resolution.session_id)
+
+      expect(confirmation.success).to eq false
+    end
+  end
 end


### PR DESCRIPTION
Proofers vary. Offer more basic methods that map to NIST verification requirements.