### PR TITLE
Fix detection of bad mock SSN

### DIFF
--- a/lib/proofer/vendor/mock.rb
+++ b/lib/proofer/vendor/mock.rb
@@ -45,7 +45,7 @@ module Proofer
         uuid = SecureRandom.uuid
         if applicant.first_name =~ /Bad/i
           failed_resolution({ error: 'bad first name' }, uuid)
-        elsif applicant.ssn == '6666'
+        elsif applicant.ssn =~ /6666/
           failed_resolution({ error: 'bad SSN' }, uuid)
         else
           successful_resolution({ kbv: 'some questions here' }, uuid)


### PR DESCRIPTION
**Why**: SSN may be full 9 digits, so compare 6666 with regexp instead
of straight equality.