### PR TITLE
Add .errors to Confirmation and Resolution

### DIFF
--- a/lib/proofer/confirmation.rb
+++ b/lib/proofer/confirmation.rb
@@ -1,10 +1,11 @@
 module Proofer
   class Confirmation
-    attr_accessor :success, :vendor_resp
+    attr_accessor :success, :vendor_resp, :errors
 
     def initialize(opts)
       self.success = opts[:success]
       self.vendor_resp = opts[:vendor_resp]
+      self.errors = opts[:errors]
     end
 
     def success?

--- a/lib/proofer/resolution.rb
+++ b/lib/proofer/resolution.rb
@@ -2,12 +2,13 @@ require 'proofer/question_set'
 
 module Proofer
   class Resolution
-    attr_accessor :success, :questions, :vendor_resp, :session_id
+    attr_accessor :success, :questions, :vendor_resp, :session_id, :errors
 
     def initialize(opts)
       self.success = opts[:success]
       self.vendor_resp = opts[:vendor_resp]
       self.session_id = opts[:session_id]
+      self.errors = opts[:errors]
       questions = opts[:questions]
       if questions && questions.is_a?(Proofer::QuestionSet)
         self.questions = questions

--- a/lib/proofer/vendor/vendor_base.rb
+++ b/lib/proofer/vendor/vendor_base.rb
@@ -55,11 +55,12 @@ module Proofer
         )
       end
 
-      def failed_resolution(vendor_resp, session_id)
+      def failed_resolution(vendor_resp, session_id, errors = {})
         Proofer::Resolution.new(
           success: false,
           vendor_resp: vendor_resp,
-          session_id: session_id
+          session_id: session_id,
+          errors: errors
         )
       end
 
@@ -72,8 +73,8 @@ module Proofer
         Proofer::Confirmation.new success: true, vendor_resp: vendor_resp
       end
 
-      def failed_confirmation(vendor_resp)
-        Proofer::Confirmation.new success: false, vendor_resp: vendor_resp
+      def failed_confirmation(vendor_resp, errors = {})
+        Proofer::Confirmation.new success: false, vendor_resp: vendor_resp, errors: errors
       end
     end
   end

--- a/spec/lib/proofer/vendor/mock_spec.rb
+++ b/spec/lib/proofer/vendor/mock_spec.rb
@@ -53,6 +53,7 @@ describe Proofer::Vendor::Mock do
       expect(resolution).to be_a Proofer::Resolution
       expect(resolution.success).to eq false
       expect(resolution.questions).to be_nil
+      expect(resolution.errors).to eq(first_name: 'Unverified first name.')
     end
 
     it 'fails on 6666 SSN' do
@@ -62,6 +63,7 @@ describe Proofer::Vendor::Mock do
       expect(resolution).to be_a Proofer::Resolution
       expect(resolution.success).to eq false
       expect(resolution.questions).to be_nil
+      expect(resolution.errors).to eq(ssn: 'Unverified SSN.')
     end
   end
 
@@ -121,12 +123,13 @@ describe Proofer::Vendor::Mock do
         confirmation = mocker.submit_financials({ finance_type => '00000000' }, resolution.session_id)
 
         expect(confirmation.success).to eq false
+        expect(confirmation.errors).to eq(finance_type => "The #{finance_type} could not be verified.")
       end
     end
   end
 
   describe '#submit_phone' do
-    it 'succeeds with all fives' do
+    it 'succeeds with valid number' do
       mocker = described_class.new applicant: applicant
       resolution = mocker.start
       confirmation = mocker.submit_phone('(555) 555-0000', resolution.session_id)
@@ -142,12 +145,13 @@ describe Proofer::Vendor::Mock do
       expect(confirmation.success).to eq true
     end
 
-    it 'fails without all fives' do
+    it 'fails with all fives' do
       mocker = described_class.new applicant: applicant
       resolution = mocker.start
       confirmation = mocker.submit_phone('(555) 555-5555', resolution.session_id)
 
       expect(confirmation.success).to eq false
+      expect(confirmation.errors).to eq(phone: 'The phone number could not be verified.')
     end
   end
 end


### PR DESCRIPTION
**Why**: Vendor-specific gems may parse upstream responses to provide
uniform error messaging.