### PR TITLE
Add mock failure for suspect ZIP code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,7 @@ Metrics/ClassLength:
   CountComments: false
   Max: 150
   Exclude:
+  - lib/proofer/vendor/mock.rb
   - spec/**/*
 
 Metrics/LineLength:

--- a/lib/proofer/vendor/mock.rb
+++ b/lib/proofer/vendor/mock.rb
@@ -55,6 +55,8 @@ module Proofer
           fail_resolution_with_bad_name(uuid)
         elsif applicant.ssn =~ /6666/
           fail_resolution_with_bad_ssn(uuid)
+        elsif applicant.zipcode == '00000'
+          fail_resolution_with_bad_zipcode(uuid)
         else
           pass_resolution(uuid)
         end
@@ -137,6 +139,14 @@ module Proofer
           MockResponse.new(error: 'bad SSN', reasons: ['The SSN was suspicious']),
           uuid,
           ssn: 'Unverified SSN.'
+        )
+      end
+
+      def fail_resolution_with_bad_zipcode(uuid)
+        failed_resolution(
+          MockResponse.new(error: 'bad address', reasons: ['The ZIP code was suspicious']),
+          uuid,
+          zipcode: 'Unverified ZIP code.'
         )
       end
 

--- a/spec/lib/proofer/vendor/mock_spec.rb
+++ b/spec/lib/proofer/vendor/mock_spec.rb
@@ -70,6 +70,17 @@ describe Proofer::Vendor::Mock do
       expect(resolution.errors).to eq(ssn: 'Unverified SSN.')
       expect(resolution.vendor_resp.reasons).to include 'The SSN was suspicious'
     end
+
+    it 'fails on 00000 zipcode' do
+      mocker = described_class.new
+      resolution = mocker.start zipcode: '00000'
+
+      expect(resolution).to be_a Proofer::Resolution
+      expect(resolution.success).to eq false
+      expect(resolution.questions).to be_nil
+      expect(resolution.errors).to eq(zipcode: 'Unverified ZIP code.')
+      expect(resolution.vendor_resp.reasons).to include 'The ZIP code was suspicious'
+    end
   end
 
   describe '#submit_answers' do


### PR DESCRIPTION
**Why**: Generate failure for address.