### PR TITLE
Add previous address attributes to Applicant

### DIFF
--- a/lib/proofer/applicant.rb
+++ b/lib/proofer/applicant.rb
@@ -2,6 +2,7 @@ module Proofer
   class Applicant
     attr_accessor :first_name, :last_name, :middle_name, :gen
     attr_accessor :address1, :address2, :city, :state, :zipcode
+    attr_accessor :prev_address1, :prev_address2, :prev_city, :prev_state, :prev_zipcode
     attr_accessor :ssn, :dob, :phone, :email
     attr_accessor :drivers_license_state, :drivers_license_id, :passport_id, :military_id
     attr_accessor :ccn, :mortgage, :home_equity_line, :auto_loan, :bank_acct, :bank_routing

--- a/lib/proofer/vendor/mock.rb
+++ b/lib/proofer/vendor/mock.rb
@@ -55,7 +55,7 @@ module Proofer
           fail_resolution_with_bad_name(uuid)
         elsif applicant.ssn =~ /6666/
           fail_resolution_with_bad_ssn(uuid)
-        elsif applicant.zipcode == '00000'
+        elsif looks_like_bad_zipcode(applicant)
           fail_resolution_with_bad_zipcode(uuid)
         else
           pass_resolution(uuid)
@@ -118,6 +118,10 @@ module Proofer
       # rubocop:enable all
 
       private
+
+      def looks_like_bad_zipcode(applicant)
+        applicant.zipcode == '00000' || applicant.prev_zipcode == '00000'
+      end
 
       def fail_confirmation_with_bad_phone(session_id)
         failed_confirmation(

--- a/spec/lib/proofer/vendor/mock_spec.rb
+++ b/spec/lib/proofer/vendor/mock_spec.rb
@@ -72,14 +72,16 @@ describe Proofer::Vendor::Mock do
     end
 
     it 'fails on 00000 zipcode' do
-      mocker = described_class.new
-      resolution = mocker.start zipcode: '00000'
+      [:zipcode, :prev_zipcode].each do |zipcode|
+        mocker = described_class.new
+        resolution = mocker.start zipcode => '00000'
 
-      expect(resolution).to be_a Proofer::Resolution
-      expect(resolution.success).to eq false
-      expect(resolution.questions).to be_nil
-      expect(resolution.errors).to eq(zipcode: 'Unverified ZIP code.')
-      expect(resolution.vendor_resp.reasons).to include 'The ZIP code was suspicious'
+        expect(resolution).to be_a Proofer::Resolution
+        expect(resolution.success).to eq false
+        expect(resolution.questions).to be_nil
+        expect(resolution.errors).to eq(zipcode: 'Unverified ZIP code.')
+        expect(resolution.vendor_resp.reasons).to include 'The ZIP code was suspicious'
+      end
     end
   end
 


### PR DESCRIPTION
**Why**: some vendors support multiple addresses for resolution.