### PR TITLE
Add vendor_resp.normalized_applicant to mock

### DIFF
--- a/.reek
+++ b/.reek
@@ -23,3 +23,5 @@ ControlParameter:
     - Proofer::Vendor::Mock#submit_phone
 TooManyStatements:
   max_statements: 8
+TooManyMethods:
+  max_methods: 20

--- a/lib/proofer/vendor/mock.rb
+++ b/lib/proofer/vendor/mock.rb
@@ -132,7 +132,10 @@ module Proofer
 
       def fail_resolution_with_bad_name(uuid)
         failed_resolution(
-          MockResponse.new(error: 'bad first name', reasons: ['The name was suspicious']),
+          MockResponse.new(
+            error: 'bad first name', reasons: ['The name was suspicious'],
+            normalized_applicant: normalized_applicant
+          ),
           uuid,
           first_name: 'Unverified first name.'
         )
@@ -140,7 +143,10 @@ module Proofer
 
       def fail_resolution_with_bad_ssn(uuid)
         failed_resolution(
-          MockResponse.new(error: 'bad SSN', reasons: ['The SSN was suspicious']),
+          MockResponse.new(
+            error: 'bad SSN', reasons: ['The SSN was suspicious'],
+            normalized_applicant: normalized_applicant
+          ),
           uuid,
           ssn: 'Unverified SSN.'
         )
@@ -148,7 +154,10 @@ module Proofer
 
       def fail_resolution_with_bad_zipcode(uuid)
         failed_resolution(
-          MockResponse.new(error: 'bad address', reasons: ['The ZIP code was suspicious']),
+          MockResponse.new(
+            normalized_applicant: normalized_applicant,
+            error: 'bad address', reasons: ['The ZIP code was suspicious']
+          ),
           uuid,
           zipcode: 'Unverified ZIP code.'
         )
@@ -156,9 +165,30 @@ module Proofer
 
       def pass_resolution(uuid)
         successful_resolution(
-          MockResponse.new(reasons: ['Everything looks good'], kbv: 'some questions here'),
-          uuid
+          MockResponse.new(
+            normalized_applicant: normalized_applicant,
+            reasons: ['Everything looks good'],
+            kbv: 'some questions here'
+          ), uuid
         )
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def normalized_applicant
+        Proofer::Applicant.new(
+          first_name: normalize(applicant.first_name),
+          last_name: normalize(applicant.last_name),
+          address1: normalize(applicant.address1).sub(/ST$/, 'STREET'),
+          address2: normalize(applicant.address2),
+          city: normalize(applicant.city).sub('ST.', 'SAINT'),
+          state: normalize(applicant.state),
+          zipcode: normalize(applicant.zipcode).sub(/^(\d\d\d\d\d)$/, '\1-1234')
+        )
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      def normalize(str)
+        str ? str.upcase : ''
       end
 
       def financial_errors(financials)

--- a/spec/lib/proofer/vendor/mock_spec.rb
+++ b/spec/lib/proofer/vendor/mock_spec.rb
@@ -10,7 +10,7 @@ describe Proofer::Vendor::Mock do
       dob: '19700501',
       ssn: '666123456',
       address1: '1234 Main St',
-      city: 'Anytown',
+      city: 'St. Somewhere',
       state: 'KS',
       zipcode: '66666'
     }
@@ -47,6 +47,19 @@ describe Proofer::Vendor::Mock do
       expect(resolution.errors).to eq({})
       expect(resolution.session_id).to_not be_nil
       expect(resolution.questions).to be_nil
+    end
+
+    it 'returns normalized Applicant values' do
+      mocker = described_class.new kbv: false
+      resolution = mocker.start applicant
+
+      norm_applicant = resolution.vendor_resp.normalized_applicant
+      expect(norm_applicant).to be_a Proofer::Applicant
+      expect(norm_applicant.city).to eq 'SAINT SOMEWHERE'
+      expect(norm_applicant.zipcode).to eq '66666-1234'
+      expect(norm_applicant.address1).to eq '1234 MAIN STREET'
+      expect(norm_applicant.first_name).to eq 'SOME'
+      expect(norm_applicant.last_name).to eq 'ONE'
     end
 
     it 'fails on Bad first name' do


### PR DESCRIPTION
**Why**: Pretend that the vendor can return "corrected"
values for applicant attributes.