### PR TITLE
Add Applicant.to_hash method

### DIFF
--- a/lib/proofer/applicant.rb
+++ b/lib/proofer/applicant.rb
@@ -15,5 +15,11 @@ module Proofer
         instance_variable_set("@#{attr}", value)
       end
     end
+
+    def to_hash
+      instance_variables.each_with_object({}) do |var, hash|
+        hash[var.to_s.delete('@')] = instance_variable_get(var)
+      end
+    end
   end
 end

--- a/spec/lib/proofer/applicant_spec.rb
+++ b/spec/lib/proofer/applicant_spec.rb
@@ -13,4 +13,12 @@ describe Proofer::Applicant do
       end.to raise_error ArgumentError
     end
   end
+
+  describe '#to_hash' do
+    it 'returns a Hash' do
+      applicant = described_class.new first_name: 'Sue', last_name: 'Me'
+
+      expect(applicant.to_hash).to eq('first_name' => 'Sue', 'last_name' => 'Me')
+    end
+  end
 end


### PR DESCRIPTION
**WHY**: Convenience for serialization.