### PR TITLE
Replace Travis with Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # Specify the Ruby version you desire here
+      - image: circleci/ruby:2.3.4
+        environment:
+
+    working_directory: ~/identity-proofer-gem
+
+    steps:
+      - checkout
+
+      - restore-cache:
+          key: identity-proofer-gem-{{ checksum "Gemfile.lock" }}
+
+      - run:
+          name: Install dependencies
+          command: |
+            gem install bundler
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      # Store bundle cache
+      - save-cache:
+          key: identity-proofer-gem-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+
+      - run:
+          name: Run Tests
+          command: |
+            bundle exec rake test
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-notifications:
-  email: false
-language: ruby
-rvm:
-- 2.3.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,37 @@
+PATH
+  remote: .
+  specs:
+    proofer (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    dotenv (2.2.1)
+    rake (12.0.0)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler
+  dotenv
+  proofer!
+  rake
+  rspec
+
+BUNDLED WITH
+   1.15.3


### PR DESCRIPTION
**Why**: Travis will soon no longer be supported/allowed at 18F.
Circle CI is the service that has been approved.

Note that this PR uses Circle CI 2.0. See docs here for Ruby projects:
https://circleci.com/docs/2.0/language-ruby/