### PR TITLE
Change bank acct to checking and savings acct

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ confirmation = agent.submit_financials(
 confirmation.success? # => true
 confirmation.errors # A hash of errors if errors occur
 
+# Submit financials w/ a bank account
+confirmation = agent.submit_financials(
+  bank_account: '123456789',
+  bank_account_type: :savings,
+  bank_routing: '987654321',
+)
+confirmation.success? # => true
+confirmation.errors # A hash of errors if errors occur
+
 # Submit Phone
 confirmation = agent.submit_phone(
   '2065555000',

--- a/lib/proofer/applicant.rb
+++ b/lib/proofer/applicant.rb
@@ -7,7 +7,10 @@ module Proofer
     attr_accessor :prev_address1, :prev_address2, :prev_city, :prev_state, :prev_zipcode
     attr_accessor :ssn, :dob, :phone, :email
     attr_accessor :drivers_license_state, :drivers_license_id, :passport_id, :military_id
-    attr_accessor :ccn, :mortgage, :home_equity_line, :auto_loan, :bank_acct, :bank_routing
+    attr_accessor :ccn, :mortgage, :home_equity_line, :auto_loan
+    attr_accessor :bank_account, :bank_account_type, :bank_routing
+
+    alias bank_acct bank_account
 
     def initialize(params)
       params.each do |attr, value|

--- a/spec/lib/proofer/vendor/mock_spec.rb
+++ b/spec/lib/proofer/vendor/mock_spec.rb
@@ -166,6 +166,69 @@ describe Proofer::Vendor::Mock do
         expect(confirmation.errors).to eq(finance_type => "The #{finance_type} could not be verified.")
       end
     end
+
+    it 'succeeeds with bank_account' do
+      mocker = described_class.new applicant: applicant
+      resolution = mocker.start
+      confirmation = mocker.submit_financials(
+        {
+          bank_account: '1234567',
+          bank_routing: '1234567',
+          bank_account_type: :checking
+        },
+        resolution.session_id
+      )
+
+      expect(confirmation.success).to eq true
+      expect(confirmation.errors).to eq({})
+    end
+
+    it 'fails with bad bank_account' do
+      mocker = described_class.new applicant: applicant
+      resolution = mocker.start
+      confirmation = mocker.submit_financials(
+        {
+          bank_account: '00000000',
+          bank_routing: '1234567',
+          bank_account_type: :checking
+        },
+        resolution.session_id
+      )
+
+      expect(confirmation.success).to eq false
+      expect(confirmation.errors).to eq(bank_account: 'The bank_account could not be verified.')
+    end
+
+    it 'fails with bad bank_account_type' do
+      mocker = described_class.new applicant: applicant
+      resolution = mocker.start
+      confirmation = mocker.submit_financials(
+        {
+          bank_account: '1234567',
+          bank_routing: '1234567',
+          bank_account_type: :qwerty
+        },
+        resolution.session_id
+      )
+
+      expect(confirmation.success).to eq false
+      expect(confirmation.errors).to eq(bank_account_type: 'The bank_account_type could not be verified.')
+    end
+
+    it 'fails if bank_account_type is missing' do
+      mocker = described_class.new applicant: applicant
+      resolution = mocker.start
+      confirmation = mocker.submit_financials(
+        {
+          bank_account: '1234567',
+          bank_routing: '1234567'
+        },
+        resolution.session_id
+      )
+
+      expect(confirmation.success).to eq false
+      expect(confirmation.errors).to eq(bank_account_type: 'The bank_account_type could not be verified.')
+    end
   end
 
   describe '#submit_phone' do


### PR DESCRIPTION
**Why**: To allow specification between a checking account and savings
accounts when doing verification with financials