### PR TITLE
After discussion, tagged at 1.0.1 to better reflect scope

### DIFF
--- a/lib/proofer/version.rb
+++ b/lib/proofer/version.rb
@@ -1,3 +1,3 @@
 module Proofer
-  VERSION = '2.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end


### PR DESCRIPTION
After some late discussion on #29, we decided to go with 1.0.1 instead of 2.0 after all.