### PR TITLE
Add state ID number and code to mock proofer

### DIFF
--- a/lib/proofer/agent.rb
+++ b/lib/proofer/agent.rb
@@ -2,7 +2,8 @@ module Proofer
   class Agent
     attr_accessor :vendor
     extend Forwardable
-    def_delegators :@_vendor, :applicant, :applicant=, :start, :submit_answers, :submit_financials, :submit_phone
+    def_delegators :@_vendor, :applicant, :applicant=, :start,
+                   :submit_answers, :submit_financials, :submit_phone, :submit_state_id
 
     def initialize(opts)
       self.vendor = opts[:vendor] or raise ArgumentError, ':vendor required'

--- a/lib/proofer/vendor/vendor_base.rb
+++ b/lib/proofer/vendor/vendor_base.rb
@@ -32,6 +32,10 @@ module Proofer
         raise NotImplementedError, "#{self} must implement submit_phone() method"
       end
 
+      def submit_state_id(_state_id_data, _session_id)
+        raise NotImplementedError, "#{self} must implement submit_state_id() method"
+      end
+
       def coerce_applicant(applicant)
         return if applicant.nil?
         return applicant if applicant.is_a?(Proofer::Applicant)

--- a/lib/proofer/version.rb
+++ b/lib/proofer/version.rb
@@ -1,3 +1,3 @@
 module Proofer
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/spec/lib/proofer/agent_spec.rb
+++ b/spec/lib/proofer/agent_spec.rb
@@ -46,6 +46,12 @@ describe Proofer::Agent do
 
       phone_confirmation = agent.submit_phone '(555) 555-0000'
       expect(phone_confirmation.success).to eq true
+
+      state_confirmation = agent.submit_state_id(
+        state_id_number: '123456789',
+        state_id_jurisdiction: 'WA'
+      )
+      expect(state_confirmation.success).to eq true
     end
   end
 

--- a/spec/lib/proofer/vendor/mock_spec.rb
+++ b/spec/lib/proofer/vendor/mock_spec.rb
@@ -258,4 +258,51 @@ describe Proofer::Vendor::Mock do
       expect(confirmation.errors).to eq(phone: 'The phone number could not be verified.')
     end
   end
+
+  describe '#submit_state_id' do
+    it 'succeeds with valid state id' do
+      mocker = described_class.new applicant: applicant
+      resolution = mocker.start
+      confirmation = mocker.submit_state_id(
+        {
+          state_id_number: '123456789',
+          state_id_jurisdiction: 'WA'
+        },
+        resolution.session_id
+      )
+
+      expect(confirmation.success).to eq true
+      expect(confirmation.errors).to eq({})
+    end
+
+    it 'fails with unsupported juridisction' do
+      mocker = described_class.new applicant: applicant
+      resolution = mocker.start
+      confirmation = mocker.submit_state_id(
+        {
+          state_id_number: '123456789',
+          state_id_jurisdiction: 'AL'
+        },
+        resolution.session_id
+      )
+
+      expect(confirmation.success).to eq false
+      expect(confirmation.errors).to eq(state_id_jurisdiction: 'The jurisdiction could not be verified')
+    end
+
+    it 'fails with invalid state id' do
+      mocker = described_class.new applicant: applicant
+      resolution = mocker.start
+      confirmation = mocker.submit_state_id(
+        {
+          state_id_number: '000000000',
+          state_id_jurisdiction: 'WA'
+        },
+        resolution.session_id
+      )
+
+      expect(confirmation.success).to eq false
+      expect(confirmation.errors).to eq(state_id_number: 'The state ID number could not be verified')
+    end
+  end
 end


### PR DESCRIPTION
__Why__

 To support LOA3 proofing via state ID

__How__

add state ID number and state code(required for MVP)