### PR TITLE
Refactor state id data and methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    proofer (1.0.0)
+    proofer (1.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -34,4 +34,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/lib/proofer/applicant.rb
+++ b/lib/proofer/applicant.rb
@@ -6,9 +6,9 @@ module Proofer
     attr_accessor :address1, :address2, :city, :state, :zipcode
     attr_accessor :prev_address1, :prev_address2, :prev_city, :prev_state, :prev_zipcode
     attr_accessor :ssn, :dob, :phone, :email
-    attr_accessor :drivers_license_state, :drivers_license_id, :passport_id, :military_id
     attr_accessor :ccn, :mortgage, :home_equity_line, :auto_loan
     attr_accessor :bank_account, :bank_account_type, :bank_routing
+    attr_accessor :state_id_jurisdiction, :state_id_number, :state_id_type
 
     alias bank_acct bank_account
 

--- a/lib/proofer/vendor/mock.rb
+++ b/lib/proofer/vendor/mock.rb
@@ -50,7 +50,7 @@ module Proofer
         end
       end
 
-      # rubocop:disable MethodLength
+=begin     # rubocop:disable MethodLength
       def submit_state_id(state_id_data, session_id = nil)
         if !SUPPORTED_STATES.include? state_id_data[:state_id_jurisdiction]
           failed_confirmation(
@@ -67,8 +67,51 @@ module Proofer
             MockResponse.new(session: session_id, reasons: ['valid state ID'])
           )
         end
-      end
+      end 
       # rubocop:enable MethodLength
+=end
+
+      def submit_state_id(state_id_data, session_id = nil)
+        if invalid_state_submission?(state_id_data)
+          return unsuccessful_state_confirmation 
+        elsif invalid_state_id_number?(state_id_data)
+          return unsuccessful_state_id_confirmation
+        else
+          successful_state_confirmation
+        end
+      end
+      
+      def invalid_state_submission?(state_id_data)
+        state_not_supported?(state_id_data) || invalid_state_id_number?(state_id_data)
+      end
+      
+      def state_not_supported?(state_id_data)
+       !SUPPORTED_STATES.include? state_id_data[:state_id_jurisdiction]
+      end
+      
+      def unsuccessful_state_confirmation(state_id_data, session_id = nil)
+        failed_confirmation(
+          MockResponse.new(session: session_id, reasons: ['invalid jurisdiction']),
+          state_id_jurisdiction: 'The jurisdiction could not be verified'
+        )
+      end
+
+      def successful_state_confirmation(state_id_data, session_id = nil)
+        successful_confirmation(
+          MockResponse.new(session: session_id, reasons: ['valid state ID'])
+        )
+      end
+
+      def invalid_state_id_number?(state_id_data)
+        state_id_data[:state_id_number] =~ /\A0*\z/
+      end
+
+      def unsuccessful_state_id_confirmation(state_id_data, session_id = nil)
+        failed_confirmation(
+          MockResponse.new(session: session_id, reasons: ['invalid state id number']),
+          state_id_number: 'The state ID number could not be verified'
+        )
+      end
 
       def coerce_vendor_applicant(applicant)
         Proofer::Applicant.new applicant

--- a/spec/lib/proofer/agent_spec.rb
+++ b/spec/lib/proofer/agent_spec.rb
@@ -49,6 +49,7 @@ describe Proofer::Agent do
 
       state_confirmation = agent.submit_state_id(
         state_id_number: '123456789',
+        state_id_type: 'drivers_license',
         state_id_jurisdiction: 'WA'
       )
       expect(state_confirmation.success).to eq true

--- a/spec/lib/proofer/vendor/mock_spec.rb
+++ b/spec/lib/proofer/vendor/mock_spec.rb
@@ -266,6 +266,7 @@ describe Proofer::Vendor::Mock do
       confirmation = mocker.submit_state_id(
         {
           state_id_number: '123456789',
+          state_id_type: 'drivers_license',
           state_id_jurisdiction: 'WA'
         },
         resolution.session_id
@@ -281,6 +282,7 @@ describe Proofer::Vendor::Mock do
       confirmation = mocker.submit_state_id(
         {
           state_id_number: '123456789',
+          state_id_type: 'drivers_license',
           state_id_jurisdiction: 'AL'
         },
         resolution.session_id
@@ -296,13 +298,43 @@ describe Proofer::Vendor::Mock do
       confirmation = mocker.submit_state_id(
         {
           state_id_number: '000000000',
-          state_id_jurisdiction: 'WA'
+          state_id_jurisdiction: 'WA',
+          state_id_type: 'drivers_license'
         },
         resolution.session_id
       )
 
       expect(confirmation.success).to eq false
       expect(confirmation.errors).to eq(state_id_number: 'The state ID number could not be verified')
+    end
+
+    it 'fails with invalid state id type' do
+      mocker = described_class.new applicant: applicant
+      resolution = mocker.start
+      confirmation = mocker.submit_state_id(
+        {
+          state_id_number: '123456789',
+          state_id_jurisdiction: 'WA',
+          state_id_type: 'drivers_permit'
+        },
+        resolution.session_id
+      )
+      expect(confirmation.success).to eq false
+      expect(confirmation.errors).to eq(state_id_type: 'The state ID type could not be verified')
+    end
+
+    it 'fails with nil state id type' do
+      mocker = described_class.new applicant: applicant
+      resolution = mocker.start
+      confirmation = mocker.submit_state_id(
+        {
+          state_id_number: '123456789',
+          state_id_jurisdiction: 'WA'
+        },
+        resolution.session_id
+      )
+      expect(confirmation.success).to eq false
+      expect(confirmation.errors).to eq(state_id_type: 'The state ID type could not be verified')
     end
   end
 end


### PR DESCRIPTION

__Why__

* it makes code  mantainable and avoid bypassing rubocop.
* add state id type to state id data

__How__

* replace old applicant data with current state id data
* break submit_state_id method into  "single responsibility" methods
* add unit tests for state id type(invalid and nil)

