### PR TITLE
Add driver's permit to permitted state id types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    proofer (1.1.0)
+    proofer (1.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/proofer/vendor/mock.rb
+++ b/lib/proofer/vendor/mock.rb
@@ -18,7 +18,7 @@ module Proofer
       ).freeze
 
       SUPPORTED_STATE_ID_TYPES = %w(
-        drivers_license state_id_card
+        drivers_license drivers_permit state_id_card
       ).freeze
 
       def submit_answers(question_set, session_id = nil)

--- a/lib/proofer/version.rb
+++ b/lib/proofer/version.rb
@@ -1,3 +1,3 @@
 module Proofer
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.1.2'.freeze
 end

--- a/spec/lib/proofer/vendor/mock_spec.rb
+++ b/spec/lib/proofer/vendor/mock_spec.rb
@@ -315,7 +315,7 @@ describe Proofer::Vendor::Mock do
         {
           state_id_number: '123456789',
           state_id_jurisdiction: 'WA',
-          state_id_type: 'drivers_permit'
+          state_id_type: 'passport'
         },
         resolution.session_id
       )


### PR DESCRIPTION
**Why**: A driver's permit is a type of state id that vendors recognize as distinct from a driver's license