### PR TITLE
Update list of allowed states for id verification

### DIFF
--- a/lib/proofer/vendor/mock.rb
+++ b/lib/proofer/vendor/mock.rb
@@ -14,7 +14,7 @@ module Proofer
       }.freeze
 
       SUPPORTED_STATES = %w(
-        AR AZ CA DC DE FL IA ID IL IN KY MD ME MI MS NA ND NE NM PA SD TX VA WA WI
+        AR AZ CO DC DE FL IA ID IL IN KY MA MD ME MI MS MT ND NE NJ NM PA SD TX VA WA WI WY
       ).freeze
 
       SUPPORTED_STATE_ID_TYPES = %w(

--- a/lib/proofer/version.rb
+++ b/lib/proofer/version.rb
@@ -1,3 +1,3 @@
 module Proofer
-  VERSION = '1.1.2'.freeze
+  VERSION = '1.1.3'.freeze
 end


### PR DESCRIPTION
**Why**: AAAMVA added some more states and we misspelled MA as NA
and CA was listed as supported instead of CO.