### PR TITLE
Add support for specifying proofer logic with a symbol

### DIFF
--- a/.reek
+++ b/.reek
@@ -22,6 +22,7 @@ NilCheck:
 ControlParameter:
   exclude:
     - Proofer::Vendor::Mock#submit_phone
+    - Proofer::Base#proof
 TooManyStatements:
   max_statements: 8
 TooManyMethods:

--- a/lib/proofer/v2/base.rb
+++ b/lib/proofer/v2/base.rb
@@ -17,8 +17,8 @@ module Proofer
         @supported_stage = stage
       end
 
-      def proof(&block)
-        @proofer = block
+      def proof(sym = nil, &block)
+        @proofer = sym || block
       end
     end
 
@@ -26,13 +26,21 @@ module Proofer
       vendor_applicant = restrict_attributes(applicant)
       validate_attributes(vendor_applicant)
       result = Proofer::Result.new
-      instance_exec(vendor_applicant, result, &proofer)
+      execute_proof(proofer, vendor_applicant, result)
       result
     rescue StandardError => exception
       Proofer::Result.new(exception: exception)
     end
 
     private
+
+    def execute_proof(proofer, *args)
+      if proofer.is_a? Symbol
+        send(proofer, *args)
+      else
+        instance_exec(*args, &proofer)
+      end
+    end
 
     def restrict_attributes(applicant)
       applicant.select { |attribute| required_attributes.include?(attribute) }

--- a/lib/proofer/version.rb
+++ b/lib/proofer/version.rb
@@ -1,3 +1,3 @@
 module Proofer
-  VERSION = '2.3.0'.freeze
+  VERSION = '2.4.0'.freeze
 end


### PR DESCRIPTION
**WHY**
Most of the time the vendor implementation will want the actual
proofing logic specified in an instance method for simplicity and
ease of testing, resulting in the block provided to `proof` just
calling that method.

**HOW**
Alloe the implementation to provide a symbol that names the method
to call on the implementation, instead of a block, and execute that
method.