### PR TITLE
Change names of api and internal variables

### DIFF
--- a/.reek
+++ b/.reek
@@ -23,7 +23,12 @@ ControlParameter:
   exclude:
     - Proofer::Vendor::Mock#submit_phone
     - Proofer::Base#proof
+    - Proofer::Base#stage
+    - Proofer::Base#vendor_name
 TooManyStatements:
   max_statements: 8
 TooManyMethods:
   max_methods: 20
+InstanceVariableAssumption:
+  exclude:
+      - 'Proofer::Base'

--- a/lib/proofer/v2/base.rb
+++ b/lib/proofer/v2/base.rb
@@ -2,19 +2,23 @@ require 'set'
 
 module Proofer
   class Base
-    class << self
-      attr_reader :required_attributes, :supported_stage, :proofer, :vendor_name
+    @vendor_name = nil
+    @attributes = []
+    @stage = nil
 
-      def name(name)
-        @vendor_name = name
+    class << self
+      attr_reader :proofer
+
+      def vendor_name(name = nil)
+        @vendor_name = name || @vendor_name
       end
 
       def attributes(*attributes)
-        @required_attributes = attributes
+        @attributes = attributes.empty? ? @attributes : attributes
       end
 
-      def stage(stage)
-        @supported_stage = stage
+      def stage(stage = nil)
+        @stage = stage || @stage
       end
 
       def proof(sym = nil, &block)
@@ -43,26 +47,26 @@ module Proofer
     end
 
     def restrict_attributes(applicant)
-      applicant.select { |attribute| required_attributes.include?(attribute) }
+      applicant.select { |attribute| attributes.include?(attribute) }
     end
 
     def validate_attributes(applicant)
       empty_attributes = applicant.select { |_, attribute| blank?(attribute) }.keys
-      missing_attributes = required_attributes - applicant.keys
+      missing_attributes = attributes - applicant.keys
       bad_attributes = (empty_attributes | missing_attributes)
       raise error_message(bad_attributes) if bad_attributes.any?
     end
 
-    def error_message(attributes)
-      "Required attributes #{attributes.join(', ')} are not present"
+    def error_message(required_attributes)
+      "Required attributes #{required_attributes.join(', ')} are not present"
     end
 
-    def required_attributes
-      self.class.required_attributes
+    def attributes
+      self.class.attributes
     end
 
-    def supported_stage
-      self.class.supported_stage
+    def stage
+      self.class.stage
     end
 
     def proofer

--- a/lib/proofer/version.rb
+++ b/lib/proofer/version.rb
@@ -1,3 +1,3 @@
 module Proofer
-  VERSION = '2.4.0'.freeze
+  VERSION = '2.5.0'.freeze
 end

--- a/spec/lib/proofer/v2/base_spec.rb
+++ b/spec/lib/proofer/v2/base_spec.rb
@@ -18,19 +18,19 @@ describe Proofer::Base do
     }
   end
 
-  describe '.required_attributes' do
+  describe '.attributes' do
     let(:attributes) { %i[foo bar] }
-    it 'stores the required attributes and exposes them via `required_attributes`' do
+    it 'stores the required attributes and exposes them via `attributes`' do
       impl.attributes(*attributes)
-      expect(impl.required_attributes).to eq(attributes)
+      expect(impl.attributes).to eq(attributes)
     end
   end
 
   describe '.stage' do
     let(:stage) { :foo }
-    it 'stores the stage and exposes it via `suuported_stage`' do
+    it 'stores the stage and exposes it via `stage`' do
       impl.stage(stage)
-      expect(impl.supported_stage).to eq(stage)
+      expect(impl.stage).to eq(stage)
     end
   end
 
@@ -52,10 +52,10 @@ describe Proofer::Base do
     end
   end
 
-  describe '.name' do
+  describe '.vendor_name' do
     let(:name) { 'foobar:baz' }
     it 'stores the name and exposes it via `vendor_name`' do
-      impl.name(name)
+      impl.vendor_name(name)
       expect(impl.vendor_name).to eq(name)
     end
   end
@@ -206,6 +206,25 @@ describe Proofer::Base do
       it 'returns a successful result' do
         expect(instance).to receive(:hello).
           with(restricted_applicant, an_instance_of(Proofer::Result))
+        expect(subject.exception?).to eq(false)
+        expect(subject.failed?).to eq(false)
+        expect(subject.success?).to eq(true)
+        expect(subject.errors).to be_empty
+        expect(subject.messages).to be_empty
+        expect(subject.exception).to be_nil
+      end
+    end
+
+    context 'when another proofer exists' do
+      let(:logic) { proc {} }
+
+      subject { impl.new.proof(applicant) }
+
+      it 'does not affect the other proofer' do
+        impl2 = Class.new(Proofer::Base) do
+          attributes :foobarbaz
+        end
+
         expect(subject.exception?).to eq(false)
         expect(subject.failed?).to eq(false)
         expect(subject.success?).to eq(true)

--- a/spec/lib/proofer/v2/base_spec.rb
+++ b/spec/lib/proofer/v2/base_spec.rb
@@ -221,9 +221,12 @@ describe Proofer::Base do
       subject { impl.new.proof(applicant) }
 
       it 'does not affect the other proofer' do
+        # rubocop:disable Lint/UselessAssignment
+        # This is an explicit check for class-level side effects
         impl2 = Class.new(Proofer::Base) do
           attributes :foobarbaz
         end
+        # rubocop:enable Lint/UselessAssignment
 
         expect(subject.exception?).to eq(false)
         expect(subject.failed?).to eq(false)


### PR DESCRIPTION
**WHY**
Proofer::Base.name is overriding Object.name which is a problem.

**HOW**
Change to `vendor_name`, change internal variable names to match
api and update how getters/setters are handled to accommodate this.

Add a test to make sure each proofer gets its own state (class instance variables)