### PR TITLE
LG-391 Allow for optional attributes

### DIFF
--- a/.reek
+++ b/.reek
@@ -29,6 +29,9 @@ TooManyStatements:
   max_statements: 8
 TooManyMethods:
   max_methods: 20
+TooManyInstanceVariables:
+  exclude:
+    - Proofer::Base
 InstanceVariableAssumption:
   exclude:
       - 'Proofer::Base'

--- a/lib/proofer/base.rb
+++ b/lib/proofer/base.rb
@@ -3,7 +3,8 @@ require 'set'
 module Proofer
   class Base
     @vendor_name = nil
-    @attributes = []
+    @required_attributes = []
+    @optional_attributes = []
     @stage = nil
 
     class << self
@@ -13,8 +14,18 @@ module Proofer
         @vendor_name = name || @vendor_name
       end
 
-      def attributes(*attributes)
-        @attributes = attributes.empty? ? @attributes : attributes
+      def required_attributes(*required_attributes)
+        return @required_attributes if required_attributes.empty?
+        @required_attributes = required_attributes
+      end
+
+      def optional_attributes(*optional_attributes)
+        return @optional_attributes if optional_attributes.empty?
+        @optional_attributes = optional_attributes
+      end
+
+      def attributes
+        required_attributes.concat optional_attributes
       end
 
       def stage(stage = nil)
@@ -53,12 +64,20 @@ module Proofer
     def validate_attributes(applicant)
       empty_attributes = applicant.select { |_, attribute| blank?(attribute) }.keys
       missing_attributes = attributes - applicant.keys
-      bad_attributes = (empty_attributes | missing_attributes)
+      bad_attributes = (empty_attributes | missing_attributes) - optional_attributes
       raise error_message(bad_attributes) if bad_attributes.any?
     end
 
     def error_message(required_attributes)
       "Required attributes #{required_attributes.join(', ')} are not present"
+    end
+
+    def required_attributes
+      self.class.required_attributes
+    end
+
+    def optional_attributes
+      self.class.optional_attributes
     end
 
     def attributes

--- a/lib/proofer/version.rb
+++ b/lib/proofer/version.rb
@@ -1,3 +1,3 @@
 module Proofer
-  VERSION = '2.5.1'.freeze
+  VERSION = '2.6.0'.freeze
 end

--- a/proofer.gemspec
+++ b/proofer.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5.0'
 
   s.add_development_dependency('bundler')
+  s.add_development_dependency('pry-byebug')
   s.add_development_dependency('rake')
   s.add_development_dependency('reek')
   s.add_development_dependency('rspec')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'pry-byebug'
+
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
**Why**: Some proofing steps have optional attributes, for example,
address line 2 in the profile step