### PR TITLE
Default optional attributes to empty array

### DIFF
--- a/lib/proofer/base.rb
+++ b/lib/proofer/base.rb
@@ -15,12 +15,12 @@ module Proofer
       end
 
       def required_attributes(*required_attributes)
-        return @required_attributes if required_attributes.empty?
+        return @required_attributes || [] if required_attributes.empty?
         @required_attributes = required_attributes
       end
 
       def optional_attributes(*optional_attributes)
-        return @optional_attributes if optional_attributes.empty?
+        return @optional_attributes || [] if optional_attributes.empty?
         @optional_attributes = optional_attributes
       end
 

--- a/lib/proofer/version.rb
+++ b/lib/proofer/version.rb
@@ -1,3 +1,3 @@
 module Proofer
-  VERSION = '2.6.0'.freeze
+  VERSION = '2.6.1'.freeze
 end

--- a/spec/lib/proofer/base_spec.rb
+++ b/spec/lib/proofer/base_spec.rb
@@ -37,10 +37,16 @@ describe Proofer::Base do
   describe '.attributes' do
     let(:required_attributes) { %i[foo bar] }
     let(:optional_attributes) { %i[abc xyz] }
+
     it 'returns the list of combined required and optional attributes' do
       impl.required_attributes(*required_attributes)
       impl.optional_attributes(*optional_attributes)
       expect(impl.attributes).to eq(%i[foo bar abc xyz])
+    end
+
+    it 'does not raise if optional attributes are not specified' do
+      impl.required_attributes(*required_attributes)
+      expect(impl.required_attributes).to eq(required_attributes)
     end
   end
 


### PR DESCRIPTION
**Why**: The code that uses the proofer base expects optional attributes
to be an array. Subclasses of base should not be expected to set
optional attributes. If they don't this causes errors because optional
attributes is nil instead of an array.