### PR TITLE
Allow non-string types for applicant attributes

### DIFF
--- a/lib/proofer/base.rb
+++ b/lib/proofer/base.rb
@@ -93,7 +93,7 @@ module Proofer
     end
 
     def blank?(val)
-      !val || val.empty?
+      !val || val.to_s.empty?
     end
   end
 end

--- a/lib/proofer/version.rb
+++ b/lib/proofer/version.rb
@@ -1,3 +1,3 @@
 module Proofer
-  VERSION = '2.7.1'.freeze
+  VERSION = '2.8.0'.freeze
 end

--- a/spec/lib/proofer/base_spec.rb
+++ b/spec/lib/proofer/base_spec.rb
@@ -99,7 +99,7 @@ describe Proofer::Base do
 
   describe '#validate_attributes' do
     let(:required_attributes) { %i[first_name last_name] }
-    let(:optional_attributes) { %i[ssn] }
+    let(:optional_attributes) { %i[ssn some_boolean_feature] }
 
     before do
       impl.required_attributes(*required_attributes)
@@ -127,6 +127,14 @@ describe Proofer::Base do
 
     context 'when optional attributes are not present' do
       let(:applicant) { { first_name: 'Homer', last_name: 'Simpson' } }
+
+      it 'does not raise' do
+        expect { subject }.not_to raise_exception
+      end
+    end
+
+    context 'when optional attributes are booleans' do
+      let(:applicant) { { first_name: 'Homer', last_name: 'Simpson', some_boolean_feature: true } }
 
       it 'does not raise' do
         expect { subject }.not_to raise_exception


### PR DESCRIPTION
Context:
- I introduced a boolean applicant attribute as a feature flag

Problem:
- The "empty?" check we do blows up on non-string types
- Spec failure looks like:
- ```
  1) Proofer::Base#validate_attributes when optional attributes are booleans does not raise
     Failure/Error: expect { subject }.not_to raise_exception
     
       expected no Exception, got #<NoMethodError: undefined method `empty?' for true:TrueClass> with backtrace:
         # ./lib/proofer/base.rb:96:in `blank?'
         # ./lib/proofer/base.rb:65:in `block in validate_attributes'
         # ./lib/proofer/base.rb:65:in `select'
         # ./lib/proofer/base.rb:65:in `validate_attributes'
         # ./spec/lib/proofer/base_spec.rb:109:in `block (3 levels) in <top (required)>'
         # ./spec/lib/proofer/base_spec.rb:140:in `block (5 levels) in <top (required)>'
         # ./spec/lib/proofer/base_spec.rb:140:in `block (4 levels) in <top (required)>'
     # ./spec/lib/proofer/base_spec.rb:140:in `block (4 levels) in <top (required)>'
   ```


Solution:
- Make the empty check more flexible WRT to object types